### PR TITLE
Makefile: add install + fix docker container version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+##
+## Build phase
+##
 FROM golang:alpine AS builder
 
 RUN apk add --no-cache make
@@ -10,6 +13,9 @@ WORKDIR /go/src/github.com/blippar/aragorn
 
 RUN make VERSION="${VERSION}" COMMIT_HASH="${COMMIT_HASH}" static
 
+##
+## Runtime image
+##
 FROM alpine:latest AS runtime
 
 RUN apk add --no-cache ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,31 @@
 # Default config
-VERBOSE     ?= false
-VERSION     ?= $(shell echo `git describe --tags --dirty  2>/dev/null || echo devel`)
-COMMIT_HASH ?= $(shell echo `git rev-parse --short HEAD 2>/dev/null`)
-DATE        = $(shell echo `date "+%Y-%m-%d"`)
+VERBOSE		?= false
+VERSION		?= $(shell echo `git describe --tags --dirty 2>/dev/null || echo devel`)
+COMMIT_HASH	?= $(shell echo `git rev-parse --short HEAD 2>/dev/null`)
+DATE		 = $(shell echo `date "+%Y-%m-%d"`)
 
 # Go configuration
-GOBIN	  := $(shell which go)
-GOENV	  ?=
-GOOPT     ?=
-GOLDF      = -s -w -X main.commitHash=$(COMMIT_HASH) -X main.buildDate=$(DATE) -X main.version=$(VERSION)
+GOBIN		:= $(shell which go)
+GOENV		?=
+GOOPT		?=
+GOLDF		 = -s -w -X main.commitHash=$(COMMIT_HASH) -X main.buildDate=$(DATE) -X main.version=$(VERSION)
 
 # Docker configuration
-DOCKBIN   := $(shell which docker)
-DOCKIMG   := blippar/aragorn
-DOCKOPTS  += --build-arg VERSION="$(VERSION)" --build-arg COMMIT_HASH="$(COMMIT_HASH)"
+DOCKBIN		:= $(shell which docker)
+DOCKIMG		:= blippar/aragorn
+DOCKOPTS	+= --build-arg VERSION="$(VERSION)" --build-arg COMMIT_HASH="$(COMMIT_HASH)"
+DOCKFILE	:= Dockerfile
 
 # If run as 'make VERBOSE=true', it will pass the '-v' option to GOBIN
 ifeq ($(VERBOSE),true)
-GOOPT     += -v
+GOOPT		+= -v
 else
-DOCKOPTS  += -q
+DOCKOPTS	+= -q
 endif
 
 # Binary targets configuration
-TARGET     = ./bin/aragorn
-GOPKGDIR   = ./cmd/aragorn
+TARGET		 = ./bin/aragorn
+GOPKGDIR	 = ./cmd/aragorn
 
 # Local meta targets
 all: $(TARGET)
@@ -34,6 +35,11 @@ $(TARGET):
 	$(info >>> Building $@ from $(GOPKGDIR) using $(GOBIN))
 	$(if $(GOENV),$(info >>> with $(GOENV) and GOOPT=$(GOOPT)),)
 	$(GOENV) $(GOBIN) build $(GOOPT) -ldflags '$(GOLDF)' -o $(TARGET) $(GOPKGDIR)
+
+## Install in binary in /usr/local/bin/aragorn
+install: $(TARGET)
+	$(info >>> Install aragorn to /usr/local/bin/aragorn)
+	install -m755 $(TARGET) /usr/local/bin/aragorn
 
 # Run tests using GOBIN
 test:
@@ -48,10 +54,11 @@ static: $(TARGET)
 # Docker
 docker:
 	$(info >>> Building docker image $(DOCKIMG) using $(DOCKBIN))
-	$(DOCKBIN) build $(DOCKOPTS) -t $(DOCKIMG):$(VERSION) -t $(DOCKIMG):latest .
+	$(DOCKBIN) build $(DOCKOPTS) -f $(DOCKFILE) -t $(DOCKIMG):$(VERSION:v%=%) -t $(DOCKIMG):latest .
 
-check: ## Lint the source code
-	@echo "==> Linting source code..."
+## Lint the source code
+check:
+	$(info >>> Linting source code using gometalinter)
 	@gometalinter \
 		--deadline 10m \
 		--vendor \
@@ -76,4 +83,4 @@ clean:
 	rm -rv $(TARGET)
 
 # Always execute these targets
-.PHONY: all $(TARGET) test static docker check clean
+.PHONY: all $(TARGET) install test static docker check clean


### PR DESCRIPTION
- Add new Makefile rule:
  - `make install`: to compile and install aragorn under /usr/local
- Update Makefile to trim the `v` prefix from VERSION when building from a tag
- Update Makefile formatting

----

This was done to prepare the release of the `blippar/drone-aragorn` plugin available at https://github.com/blippar/drone-aragorn.