### PR TITLE
Use template package from std library and support templating inside headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ See golang.org/x/oauth2/clientcredentials Config [documentation](https://godoc.o
 #### HTTP URL Templating
 
 The URL path and query can be constructed from previous tests through templating.
+This features uses the templating engine from the Go standard library.
 
 ```json
 {
@@ -208,7 +209,7 @@ The URL path and query can be constructed from previous tests through templating
       "name": "Get Todo",
       "request": {
         "method": "GET",
-        "path": "/todo/{{add_todo.id}}"
+        "path": "/todo/{{.add_todo.id}}"
       }
     }
   ]

--- a/testsuite/httpexpect/config.go
+++ b/testsuite/httpexpect/config.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -17,8 +16,6 @@ import (
 	"github.com/blippar/aragorn/pkg/util/json"
 	"github.com/blippar/aragorn/testsuite"
 )
-
-var varsTmpl = regexp.MustCompile(`{{[0-9A-Za-z._-]+}}`)
 
 type Config struct {
 	Path  string  `json:"path,omitempty"`
@@ -149,8 +146,6 @@ func (t *Test) prepare(cfg *Config, client *http.Client) (*test, error) {
 	} else {
 		test.req = httpReq
 		test.description = httpReq.Method + " " + httpReq.URL.String()
-		test.urlPathQueries = varsTmpl.FindAllString(httpReq.URL.RawPath, -1)
-		test.urlQueryQueries = varsTmpl.FindAllString(httpReq.URL.RawQuery, -1)
 	}
 
 	if test.statusCode == 0 {

--- a/testsuite/httpexpect/httpexpect.go
+++ b/testsuite/httpexpect/httpexpect.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/Masterminds/sprig"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/xeipuuv/gojsonschema"
@@ -75,7 +76,7 @@ func (t *test) Run(ctx context.Context, l testsuite.Logger) {
 	if ok {
 		var b bytes.Buffer
 		if req.URL.RawPath != "" {
-			if tmpl, err := template.New("URL Path").Parse(req.URL.RawPath); err != nil {
+			if tmpl, err := template.New("URL Path").Funcs(sprig.FuncMap()).Parse(req.URL.RawPath); err != nil {
 				l.Errorf("could not parse URL path template: %v", err)
 				return
 			} else if err = tmpl.Execute(&b, md); err != nil {
@@ -88,7 +89,7 @@ func (t *test) Run(ctx context.Context, l testsuite.Logger) {
 		}
 
 		if req.URL.RawQuery != "" {
-			if tmpl, err := template.New("URL Query").Parse(req.URL.RawQuery); err != nil {
+			if tmpl, err := template.New("URL Query").Funcs(sprig.FuncMap()).Parse(req.URL.RawQuery); err != nil {
 				l.Errorf("could not parse URL query template: %v", err)
 				return
 			} else if err = tmpl.Execute(&b, md); err != nil {
@@ -101,7 +102,7 @@ func (t *test) Run(ctx context.Context, l testsuite.Logger) {
 
 		for k, v := range req.Header {
 			for idx, hdr := range v {
-				if tmpl, err := template.New("Request Header").Parse(hdr); err != nil {
+				if tmpl, err := template.New("Request Header").Funcs(sprig.FuncMap()).Parse(hdr); err != nil {
 					l.Errorf("could not parse request header '%s' template: %v", k, err)
 					return
 				} else if err = tmpl.Execute(&b, md); err != nil {

--- a/testsuite/httpexpect/httpexpect.go
+++ b/testsuite/httpexpect/httpexpect.go
@@ -109,7 +109,7 @@ func (t *test) Run(ctx context.Context, l testsuite.Logger) {
 					l.Errorf("could not execute request header '%s' template: %v", k, err)
 					return
 				}
-				req.Header[k][idx] = b.String()
+				v[idx] = b.String()
 				b.Reset()
 			}
 		}

--- a/testsuite/httpexpect/httpexpect.go
+++ b/testsuite/httpexpect/httpexpect.go
@@ -76,41 +76,32 @@ func (t *test) Run(ctx context.Context, l testsuite.Logger) {
 	if ok {
 		var b bytes.Buffer
 		if req.URL.RawPath != "" {
-			if tmpl, err := template.New("URL Path").Funcs(sprig.FuncMap()).Parse(req.URL.RawPath); err != nil {
-				l.Errorf("could not parse URL path template: %v", err)
-				return
-			} else if err = tmpl.Execute(&b, md); err != nil {
-				l.Errorf("could not execute URL path template: %v", err)
-				return
+			if tmpl, err := template.New("URL Path").Funcs(sprig.FuncMap()).Parse(req.URL.RawPath); err == nil {
+				if err = tmpl.Execute(&b, md); err == nil {
+					req.URL.Path = b.String()
+					req.URL.RawPath = ""
+				}
+				b.Reset()
 			}
-			req.URL.Path = b.String()
-			req.URL.RawPath = ""
-			b.Reset()
 		}
 
 		if req.URL.RawQuery != "" {
-			if tmpl, err := template.New("URL Query").Funcs(sprig.FuncMap()).Parse(req.URL.RawQuery); err != nil {
-				l.Errorf("could not parse URL query template: %v", err)
-				return
-			} else if err = tmpl.Execute(&b, md); err != nil {
-				l.Errorf("could not execute URL query template: %v", err)
-				return
+			if tmpl, err := template.New("URL Query").Funcs(sprig.FuncMap()).Parse(req.URL.RawQuery); err == nil {
+				if err = tmpl.Execute(&b, md); err == nil {
+					req.URL.RawQuery = b.String()
+				}
+				b.Reset()
 			}
-			req.URL.RawQuery = b.String()
-			b.Reset()
 		}
 
-		for k, v := range req.Header {
+		for _, v := range req.Header {
 			for idx, hdr := range v {
-				if tmpl, err := template.New("Request Header").Funcs(sprig.FuncMap()).Parse(hdr); err != nil {
-					l.Errorf("could not parse request header '%s' template: %v", k, err)
-					return
-				} else if err = tmpl.Execute(&b, md); err != nil {
-					l.Errorf("could not execute request header '%s' template: %v", k, err)
-					return
+				if tmpl, err := template.New("Request Header").Funcs(sprig.FuncMap()).Parse(hdr); err == nil {
+					if err = tmpl.Execute(&b, md); err != nil {
+						v[idx] = b.String()
+					}
+					b.Reset()
 				}
-				v[idx] = b.String()
-				b.Reset()
 			}
 		}
 	}


### PR DESCRIPTION
- Template parsing and execution on each value of each HTTP header does not seem very efficient to me and parallelism is maybe a bit overkill, IMO.

CC: @post-l 